### PR TITLE
✨ enable inclusion in rails 6 apps

### DIFF
--- a/rails_view_helpers.gemspec
+++ b/rails_view_helpers.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.1"
+  s.add_dependency "rails", "~> 6.0"
   s.add_dependency "jquery-rails"
 
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
we'll need this to be able to begin testing upgrades of our apps to Rails 6